### PR TITLE
Sass language id is now 'scss'

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "activationEvents": [
         "onLanguage:css",
         "onLanguage:sass",
+        "onLanguage:scss",
         "onLanguage:less"
     ],
     "main": "./out/src/extension",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import {EOL} from 'os';
 
 import jsbeautify = require('js-beautify');
 
-const languageSelectors = ['css', 'sass', 'less'];
+const languageSelectors = ['css', 'sass', 'less', 'scss'];
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed


### PR DESCRIPTION
Since 1.3, the language id is now 'scss', to avoid confusion with the indented syntax of Sass and to be consistent with other editors like Atom.
In the beginning it is recommended to keep supporting 'sass' to stay compatible with older versions of VSCode.
