### PR TITLE
Add Formatters to category list

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "categories": [
         "Languages",
+        "Formatters",
         "Other"
     ],
     "license": "MIT",


### PR DESCRIPTION
The Marketplace has introduce a new category called formatters for extensions that add formatting.
